### PR TITLE
Unassigned Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Wolvin's Prop Hunt: Enhanced 14b
+# Wolvin's Prop Hunt: Enhanced 14c
 
-Current version: 14, Revision: b, release type: Public
+Current version: 14, Revision: c, release type: Public
 
 ### Description
 Prop Hunt: Enhanced is an alternate, newer and enhanced version of the Gamemode from original prop hunt which was broken from last Garry's Mod's March 2015 update and decided to make as fixed and newer. This enhanced version is also pretty similar to the classic one, however several things like new codes, files and new features were added in the gamemode to make it

--- a/gamemodes/fretta/gamemode/cl_selectscreen.lua
+++ b/gamemodes/fretta/gamemode/cl_selectscreen.lua
@@ -300,7 +300,9 @@ function GM:ShowTeam()
 			
 		end
 		
-		TeamPanel:AddCancelButton()
+		if (  IsValid( LocalPlayer() ) && LocalPlayer():Team() == TEAM_UNASSIGNED ) then
+			TeamPanel:AddCancelButton()
+		end
 		
 	end
 	

--- a/gamemodes/prop_hunt/gamemode/init.lua
+++ b/gamemodes/prop_hunt/gamemode/init.lua
@@ -236,7 +236,7 @@ end
 	
 -- Called when a player tries to use an object
 function GM:PlayerUse(pl, ent)
-	if !pl:Alive() || pl:Team() == TEAM_SPECTATOR then return false end
+	if !pl:Alive() || pl:Team() == TEAM_SPECTATOR || pl:Team() == TEAM_UNASSIGNED then return false end
 	
 	if pl:Team() == TEAM_PROPS && pl:IsOnGround() && !pl:Crouching() && table.HasValue(USABLE_PROP_ENTITIES, ent:GetClass()) && ent:GetModel() then
 		if table.HasValue(BANNED_PROP_MODELS, ent:GetModel()) then


### PR DESCRIPTION
**Update cl_selectscreen.lua**
Makes it to where the player can't close the Team Selection when first joining the game.

**Update init.lua**
Makes it to where the Unassigned Team can't pick up an object. (even tho **Update cl_selectscreen.lua** fixes that problem, but still good to call it just in case)

**Update README.md**
Updated the Revision Version.