### PR TITLE
SetHullDuck

### DIFF
--- a/gamemodes/prop_hunt/gamemode/cl_init.lua
+++ b/gamemodes/prop_hunt/gamemode/cl_init.lua
@@ -240,10 +240,11 @@ usermessage.Hook("PlayFreezeCamSound", PlayFreezeCamSound)
 function SetHull(um)
 	hullxy = um:ReadLong()
 	hullz = um:ReadLong()
+	dhullz = um:ReadLong()
 	new_health = um:ReadLong()
 	
 	LocalPlayer():SetHull(Vector(hullxy * -1, hullxy * -1, 0), Vector(hullxy, hullxy, hullz))
-	LocalPlayer():SetHullDuck(Vector(hullxy * -1, hullxy * -1, 0), Vector(hullxy, hullxy, hullz))
+	LocalPlayer():SetHullDuck(Vector(hullxy * -1, hullxy * -1, 0), Vector(hullxy, hullxy, dhullz))
 	LocalPlayer():SetHealth(new_health)
 end
 usermessage.Hook("SetHull", SetHull)

--- a/gamemodes/prop_hunt/gamemode/init.lua
+++ b/gamemodes/prop_hunt/gamemode/init.lua
@@ -313,14 +313,25 @@ function GM:PlayerUse(pl, ent)
 			local hullxymax = math.Round(math.Max(ent:OBBMaxs().x, ent:OBBMaxs().y))
 			local hullxymin = hullxymax * -1
 			local hullz = math.Round(ent:OBBMaxs().z - ent:OBBMins().z)
+			local dhullz = hullz
+			if hullz > 10 && hullz <= 30 then
+				dhullz = hullz-(hullz*0.5)
+			elseif hullz > 30 && hullz <= 40 then
+				dhullz = hullz-(hullz*0.2)
+			elseif hullz > 40 && hullz <= 50 then
+				dhullz = hullz-(hullz*0.1)
+			else
+				dhullz = hullz
+			end
 			
 			pl:SetHull(Vector(hullxymin, hullxymin, 0), Vector(hullxymax, hullxymax, hullz))
-			pl:SetHullDuck(Vector(hullxymin, hullxymin, 0), Vector(hullxymax, hullxymax, hullz))
+			pl:SetHullDuck(Vector(hullxymin, hullxymin, 0), Vector(hullxymax, hullxymax, dhullz))
 			pl:SetHealth(new_health)
 			
 			umsg.Start("SetHull", pl)
 				umsg.Long(hullxymax)
 				umsg.Long(hullz)
+				umsg.Long(dhullz)
 				umsg.Short(new_health)
 			umsg.End()
 		end

--- a/gamemodes/prop_hunt/gamemode/player_class/class_prop.lua
+++ b/gamemodes/prop_hunt/gamemode/player_class/class_prop.lua
@@ -22,7 +22,7 @@ end
 
 -- Called when player spawns with this class
 function CLASS:OnSpawn(pl)
-	pl:SetColor( Color(255, 255, 255, 0))
+	pl:SetRenderMode( RENDERMODE_NONE )
 	pl:SetupHands()
 	pl:SetCustomCollisionCheck(true)
 	pl:SetAvoidPlayers(true)

--- a/gamemodes/prop_hunt/gamemode/player_class/class_prop.lua
+++ b/gamemodes/prop_hunt/gamemode/player_class/class_prop.lua
@@ -22,6 +22,7 @@ end
 
 -- Called when player spawns with this class
 function CLASS:OnSpawn(pl)
+	pl:SetColor( Color(255, 255, 255, 0))
 	pl:SetRenderMode( RENDERMODE_NONE )
 	pl:SetupHands()
 	pl:SetCustomCollisionCheck(true)


### PR DESCRIPTION
Since the hull was fixed, small props like the boots ph_minecraft_awakening to be blocked off from going under the tables

This will allow small props to crouch to get to certain places.