### PR TITLE
Hunter-Death Spectator glitch fix

### DIFF
--- a/gamemodes/fretta/gamemode/init.lua
+++ b/gamemodes/fretta/gamemode/init.lua
@@ -89,6 +89,8 @@ end
 ---------------------------------------------------------*/
 function GM:CanPlayerSuicide( ply )
 
+	if not GAMEMODE:InRound() then return false end
+
 	if( ply:Team() == TEAM_UNASSIGNED || ply:Team() == TEAM_SPECTATOR ) then
 		return false // no suicide in spectator mode
 	end
@@ -571,13 +573,15 @@ function GM:PlayerDeathThink( pl )
 end
 
 function GM:GetFallDamage( ply, flFallSpeed )
-	
+
+	if not GAMEMODE:InRound() then return 0 end
+
 	if ( GAMEMODE.RealisticFallDamage ) then
 		return flFallSpeed / 8
 	end
-	
+
 	return 10
-	
+
 end
 
 function GM:PostPlayerDeath( ply )

--- a/gamemodes/prop_hunt/entities/entities/ph_prop/init.lua
+++ b/gamemodes/prop_hunt/entities/entities/ph_prop/init.lua
@@ -23,7 +23,7 @@ function ENT:OnTakeDamage(dmg)
 	local inflictor = dmg:GetInflictor()
 
 	-- Health
-	if pl && pl:IsValid() && pl:Alive() && pl:IsPlayer() && attacker:IsPlayer() && dmg:GetDamage() > 0 then
+	if GAMEMODE:InRound() && pl && pl:IsValid() && pl:Alive() && pl:IsPlayer() && attacker:IsPlayer() && dmg:GetDamage() > 0 then
 		self.health = self.health - dmg:GetDamage()
 		pl:SetHealth(self.health)
 		


### PR DESCRIPTION
Prevents a prop from dying at the end of the round causing the hunter-death spectating glitch (when the prop dies at the end of the round during when the teams are swapping)